### PR TITLE
sdtest.sh: Limit maximum FIO jobs to 4

### DIFF
--- a/data/sdtest.sh
+++ b/data/sdtest.sh
@@ -4,7 +4,7 @@
 for i in 1 2 3
 do
     echo "Run" $i
-    RES=$(fio --output-format=terse /usr/share/agnostics/sd_bench.fio | cut -f 3,7,8,48,49 -d";" -)
+    RES=$(fio --output-format=terse --max-jobs=4 /usr/share/agnostics/sd_bench.fio | cut -f 3,7,8,48,49 -d";" -)
     echo "$RES"
     swri=$(echo "$RES" | head -n 2 | tail -n 1 | cut -d ";" -f 4)
     rwri=$(echo "$RES" | head -n 3 | tail -n 1 | cut -d ";" -f 5)


### PR DESCRIPTION
FIO will consume large amounts of RAM at startup leading to OOM/swapping on
systems with <=512MB of RAM. Limiting the max number of jobs to 4 (equal to
the number of jobs in the sd_bench.fio file) seems to stop this happening.