### PR TITLE
sd_bench.fio: update to exercise A2 cards more effectively

### DIFF
--- a/data/sd_bench.fio
+++ b/data/sd_bench.fio
@@ -4,8 +4,8 @@
 #
 [global]
 ioengine=libaio
-iodepth=4
-size=64m
+iodepth=32
+size=256m
 direct=1
 end_fsync=1
 directory=/var/tmp
@@ -18,7 +18,12 @@ stonewall
 
 [seq-write]
 rw=write
-bs=512k
+bs=4m
+stonewall
+
+[seq-read]
+rw=read
+bs=4m
 stonewall
 
 [rand-4k-write]


### PR DESCRIPTION
On Pi 5, Apps Class A2 cards are supported which have deep IO queues. Increase the depth that FIO uses accordingly, and extend the test file size to 256M to match the specification's benchmark conditions.

On older platforms or non-A2 cards, blk_mq will simply buffer the additional I/O without much overhead.

Also for some reason the file was DOS format.

@spl237 - as far as I know there's no plan to change the default recommendation for A1 for everything but Pi 5, but some hackery might be required to extract "am I using an A2 card on Pi 5" and use A2 minimums instead.